### PR TITLE
Add a note about the 8A lower limit to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ https://www.modbustools.com/modbus.html
 - Immediately after booting, the Shell Recharge 3.0 Wallbox first requests the Device Code register (0x4002). It expects '20802' as a response. If not, it'll continue retrying.
 - The Shell Recharge 3 Wallbox requests the 3 CT registers every 2 seconds.
 - You have to know what the max Current ( in Amps ) setting is on your Wallbox. In my case, this was set to 37.8 Amps. As soon as the fake CSMB starts reporting values higher than 37.8 Amps, my charging would decrease. Set the input_number main_maximal_current to the correct value.
+- The wallbox refuses to limit the current to a value lower than 8A. If you try to do so, the wallbox will set its limit to 0A and charging will stop (even if the car supports charging at a lower current).
 
 ## How to use the Home Assistant automation ?
 


### PR DESCRIPTION
Hi Thomas,

Thank you very much for the work you did here! I was able to reuse the research you did and the ESP configuration. (I adapted the HA part to my needs).

I noticed that the wallbox refuses to set a limit lower than 8A (and saw on the HA forums you encountered the same behaviour). I added a note to the readme about this, because at first I thought something wasn't working correctly.

Some more info: If I limit the current in my car to 6A (and put no restriction on the wallbox), charging works as expected so this is definitely an issue (or setting) on the wallbox. I attached a utp cable to it and was able to verify that the "limit" field in the local wallbox API dropped to 0 as soon as I set something lower than 8.